### PR TITLE
Minimum cut queue size

### DIFF
--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -188,7 +188,7 @@ makeLenses ''CutDbParams
 defaultCutDbParams :: ChainwebVersion -> Int -> CutDbParams
 defaultCutDbParams v ft = CutDbParams
     { _cutDbParamsInitialCutFile = Nothing
-    , _cutDbParamsBufferSize = (order g ^ (2 :: Int)) * diameter g
+    , _cutDbParamsBufferSize = (order g ^ (2 :: Int)) * max 2 (diameter g)
     , _cutDbParamsLogLevel = Warn
     , _cutDbParamsTelemetryLevel = Warn
     , _cutDbParamsFetchTimeout = ft


### PR DESCRIPTION
On the singleton graph the diameter is 0, but a cut queue with size 0 is not useful; so we set a higher cut queue size for chain graphs with smaller diameter.

This may increase the productivity of the multinode test suite a bit.

This was likely not noticed before because the cut queue is a PQueue, and PQueue never limits the size below 1.