### PR TITLE
Add more flexible readHighestCutHeaders

### DIFF
--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -516,7 +516,7 @@ withChainwebInternal conf logger peer serviceSock rocksDb pactDbDir backupDir re
                 logFunctionJson logger Info PactReplayInProgress
                 -- note that we don't use the "initial cut" from cutdb because its height depends on initialBlockHeightLimit.
                 highestCut <-
-                    unsafeMkCut v <$> readHighestCutHeaders v (logFunctionText logger) webchain (cutHashesTable rocksDb)
+                    unsafeMkCut v <$> readHighestCutHeaders mCutDb
                 lowerBoundCut <-
                     tryLimitCut webchain (fromMaybe 0 $ _cutInitialBlockHeightLimit $ _configCuts conf) highestCut
                 upperBoundCut <- forM (_cutFastForwardBlockHeightLimit $ _configCuts conf) $ \upperBound ->

--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -46,6 +46,7 @@ module Chainweb.CutDB
 -- * Cut Hashes Table
 , cutHashesTable
 , readHighestCutHeaders
+, readHighestCutHeaders'
 
 -- * CutDb
 , CutDb
@@ -464,7 +465,7 @@ startCutDb config logfun headerStore payloadStore cutHashesStore = mask_ $ do
     readInitialCut :: IO Cut
     readInitialCut = do
         unsafeMkCut v <$> do
-            hm <- readHighestCutHeaders v logg wbhdb cutHashesStore
+            hm <- readHighestCutHeaders' v logg wbhdb cutHashesStore
             initialHeightLimit <- case _cutDbParamsInitialHeightLimit config of
                 Nothing -> do
                     if _versionCode v == _versionCode mainnet
@@ -489,8 +490,8 @@ startCutDb config logfun headerStore payloadStore cutHashesStore = mask_ $ do
                     return limitedCutHeaders
                 Nothing -> return hm
 
-readHighestCutHeaders :: ChainwebVersion -> LogFunctionText -> WebBlockHeaderDb -> Casify RocksDbTable CutHashes -> IO (HM.HashMap ChainId BlockHeader)
-readHighestCutHeaders v logg wbhdb cutHashesStore = withTableIterator (unCasify cutHashesStore) $ \it -> do
+readHighestCutHeaders' :: ChainwebVersion -> LogFunctionText -> WebBlockHeaderDb -> Casify RocksDbTable CutHashes -> IO (HM.HashMap ChainId BlockHeader)
+readHighestCutHeaders' v logg wbhdb cutHashesStore = withTableIterator (unCasify cutHashesStore) $ \it -> do
     iterLast it
     go it
   where
@@ -512,16 +513,21 @@ readHighestCutHeaders v logg wbhdb cutHashesStore = withTableIterator (unCasify 
             Left e -> throwM e
             Right hm -> return hm
 
+readHighestCutHeaders :: CutDb cas -> IO (HM.HashMap ChainId BlockHeader)
+readHighestCutHeaders cutDb =
+    readHighestCutHeaders' (_chainwebVersion cutDb) (_cutDbLogFunction cutDb) wbhdb (_cutDbCutStore cutDb)
+    where
+    wbhdb = _webBlockHeaderStoreCas $ _cutDbHeaderStore cutDb
+
 fastForwardCutDb :: CutDb cas -> IO ()
 fastForwardCutDb cutDb = do
     highestCutHeaders <-
-        readHighestCutHeaders v (_cutDbLogFunction cutDb) wbhdb (_cutDbCutStore cutDb)
+        readHighestCutHeaders cutDb
     limitedCutHeaders <-
         limitCutHeaders wbhdb (fromMaybe maxBound (_cutDbFastForwardHeightLimit cutDb)) highestCutHeaders
     let limitedCut = unsafeMkCut (_chainwebVersion cutDb) limitedCutHeaders
     atomically $ writeTVar (_cutDbCut cutDb) limitedCut
   where
-    v = _chainwebVersion cutDb
     wbhdb = _webBlockHeaderStoreCas $ _cutDbHeaderStore cutDb
 
 -- | Stop the cut validation pipeline.

--- a/src/Chainweb/Pact/Backend/PactState/GrandHash/Utils.hs
+++ b/src/Chainweb/Pact/Backend/PactState/GrandHash/Utils.hs
@@ -28,7 +28,7 @@ module Chainweb.Pact.Backend.PactState.GrandHash.Utils
 import Chainweb.BlockHeader (BlockHeader, blockHeight)
 import Chainweb.BlockHeight (BlockHeight(..))
 import Chainweb.ChainId (ChainId, chainIdToText)
-import Chainweb.CutDB (cutHashesTable, readHighestCutHeaders)
+import Chainweb.CutDB (cutHashesTable, readHighestCutHeaders')
 import Chainweb.Logger (Logger, logFunctionText)
 import Chainweb.Pact.Backend.PactState (getLatestPactStateAt, getLatestBlockHeight, addChainIdLabel)
 import Chainweb.Pact.Backend.PactState.EmbeddedSnapshot (Snapshot(..))
@@ -107,7 +107,7 @@ getLatestCutHeaders :: ()
 getLatestCutHeaders v rocksDb = do
   wbhdb <- initWebBlockHeaderDb rocksDb v
   let cutHashes = cutHashesTable rocksDb
-  latestCutHeaders <- readHighestCutHeaders v (\_ _ -> pure ()) wbhdb cutHashes
+  latestCutHeaders <- readHighestCutHeaders' v (\_ _ -> pure ()) wbhdb cutHashes
   pure (wbhdb, latestCutHeaders)
 
 -- | Take the latest cut headers, and find the minimum 'BlockHeight' across

--- a/test/lib/Chainweb/Test/MultiNode.hs
+++ b/test/lib/Chainweb/Test/MultiNode.hs
@@ -437,7 +437,7 @@ pactImportTest logLevel v n rocksDb pactDir step = do
 
       latestBlockHeight <- do
         wbhdb <- initWebBlockHeaderDb rdb v
-        latestCutHeaders <- readHighestCutHeaders v (\_ _ -> pure ()) wbhdb (cutHashesTable rdb)
+        latestCutHeaders <- readHighestCutHeaders' v (\_ _ -> pure ()) wbhdb (cutHashesTable rdb)
         pure $ maximum $ fmap (view blockHeight) latestCutHeaders
 
       let targetChunkSize :: BlockHeight


### PR DESCRIPTION
CutDb is abstract, so we need both a version that takes its internals and one that takes the whole CutDb.