### PR TITLE
Extend ForkHeight to manage Fork numbers

### DIFF
--- a/src/Chainweb/BlockHeaderDB/HeaderOracle.hs
+++ b/src/Chainweb/BlockHeaderDB/HeaderOracle.hs
@@ -29,14 +29,14 @@ module Chainweb.BlockHeaderDB.HeaderOracle
     where
 
 import Chainweb.BlockHash (BlockHash)
-import Chainweb.BlockHeader (BlockHeader, blockHash, blockHeight, genesisBlockHeader)
+import Chainweb.BlockHeader (BlockHeader, blockHash, blockHeight, blockForkNumber, genesisBlockHeader)
 import Chainweb.BlockHeaderDB (BlockHeaderDb)
 import Chainweb.TreeDB (seekAncestor)
 import Chainweb.TreeDB qualified as TreeDB
 import Chainweb.Version (_chainwebVersion)
 import Chainweb.Version.Guards (minimumBlockHeaderHistory)
 import Control.Exception (Exception(..), throwIO)
-import Control.Lens (view)
+import Control.Lens
 import Numeric.Natural (Natural)
 
 -- | A 'HeaderOracle' is a 'BlockHeaderDb' with a lower and upper bound, and the only
@@ -52,7 +52,7 @@ data HeaderOracle = HeaderOracle
 --   The lower bound of the oracle is determined by the 'spvProofExpirationWindow'.
 createSpv :: BlockHeaderDb -> BlockHeader -> IO HeaderOracle
 createSpv db upperBound = do
-    let mWindow = minimumBlockHeaderHistory (_chainwebVersion upperBound) (view blockHeight upperBound)
+    let mWindow = minimumBlockHeaderHistory (_chainwebVersion upperBound) (upperBound ^. blockForkNumber) (upperBound ^. blockHeight)
     let gh = genesisBlockHeader (_chainwebVersion upperBound) upperBound
     let defaultOracle = create db gh upperBound
 

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -401,7 +401,7 @@ withChainwebInternal conf logger peer serviceSock rocksDb pactDbDir backupDir re
             (\cid x -> do
                 let mcfg = validatingMempoolConfig cid v (_configBlockGasLimit conf) (_configMinGasPrice conf)
                 -- NOTE: the gas limit may be set based on block height in future, so this approach may not be valid.
-                let maxGasLimit = fromIntegral <$> maxBlockGasLimit v maxBound
+                let maxGasLimit = fromIntegral <$> maxBlockGasLimit v maxBound maxBound
                 case maxGasLimit of
                     Just maxGasLimit'
                         | _configBlockGasLimit conf > maxGasLimit' ->

--- a/src/Chainweb/Chainweb/Configuration.hs
+++ b/src/Chainweb/Chainweb/Configuration.hs
@@ -610,7 +610,7 @@ parseVersion = constructVersion
                             ForkNever -> error "Chainweb.Chainweb.Configuration.parseVersion: the fork upper bound never occurs in this version."
                             ForkAtBlockHeight fubHeight -> HM.filterWithKey (\bh _ -> bh <= fubHeight) currentUpgrades
                             ForkAtGenesis -> winningVersion ^?! versionUpgrades . atChain cid
-                            ForkAtForkNumber _ -> currentUpgrades -- For now, version upgrades were only allowed at blok heights
+                            ForkAtForkNumber _ -> currentUpgrades -- For now, version upgrades were only allowed at block heights
                     )
                     (HS.toMap (chainIds winningVersion))
             ) fub

--- a/src/Chainweb/Chainweb/Configuration.hs
+++ b/src/Chainweb/Chainweb/Configuration.hs
@@ -605,10 +605,12 @@ parseVersion = constructVersion
             maybe (_versionUpgrades winningVersion) (\fub' ->
                 OnChains $ HM.mapWithKey
                     (\cid _ ->
-                        case winningVersion ^?! versionForks . at fub' . _Just . atChain cid of
+                        let currentUpgrades =  winningVersion ^?! versionUpgrades . atChain cid
+                        in case winningVersion ^?! versionForks . at fub' . _Just . atChain cid of
                             ForkNever -> error "Chainweb.Chainweb.Configuration.parseVersion: the fork upper bound never occurs in this version."
-                            ForkAtBlockHeight fubHeight -> HM.filterWithKey (\bh _ -> bh <= fubHeight) (winningVersion ^?! versionUpgrades . atChain cid)
+                            ForkAtBlockHeight fubHeight -> HM.filterWithKey (\bh _ -> bh <= fubHeight) currentUpgrades
                             ForkAtGenesis -> winningVersion ^?! versionUpgrades . atChain cid
+                            ForkAtForkNumber _ -> currentUpgrades -- For now, version upgrades were only allowed at blok heights
                     )
                     (HS.toMap (chainIds winningVersion))
             ) fub

--- a/src/Chainweb/ForkState.hs
+++ b/src/Chainweb/ForkState.hs
@@ -135,7 +135,7 @@ forkNumber = lens _forkNumber $ \(ForkState w) v -> ForkState
 
 
 -- Pact4 -> Pact5 transition happened during ForkNumber=0 era.
-pact4ForkNumber:: ForkNumber
+pact4ForkNumber :: ForkNumber
 pact4ForkNumber = 0
 
 -- ---------------------------------------------------------------------------

--- a/src/Chainweb/ForkState.hs
+++ b/src/Chainweb/ForkState.hs
@@ -25,6 +25,7 @@ module Chainweb.ForkState
 -- * Fork Number
 , ForkNumber(..)
 , forkNumber
+, pact4ForkNumber
 
 -- * Fork Votes
 , ForkVotes(..)
@@ -131,6 +132,11 @@ forkNumber :: Lens' ForkState ForkNumber
 forkNumber = lens _forkNumber $ \(ForkState w) v -> ForkState
     $ (w .&. 0xFFFFFFFF00000000)
     .|. (fromIntegral v .&. 0xFFFFFFFF)
+
+
+-- Pact4 -> Pact5 transition happened during ForkNumber=0 era.
+pact4ForkNumber:: ForkNumber
+pact4ForkNumber = 0
 
 -- ---------------------------------------------------------------------------
 -- Fork Votes

--- a/src/Chainweb/Pact/Backend/Compaction.hs
+++ b/src/Chainweb/Pact/Backend/Compaction.hs
@@ -772,7 +772,7 @@ doCompactRocksDb logger cwVersion cids minBlockHeight srcDb targetDb = do
       --
       -- On new enough chainweb versions, we want to only copy over
       -- the minimal number of block headers.
-      -- Note, this behaviour may be dangerous in case of changes on the miniumum block history.
+      -- Note, this behaviour may be dangerous in case of changes on the minimum block history.
       --
       -- TODO = Option to prune headers history to the minimum should be enabled by flag.
       case minimumBlockHeaderHistory cwVersion (latestHeader ^. blockForkNumber) (latestHeader ^. blockHeight) of

--- a/src/Chainweb/Pact/Backend/Compaction.hs
+++ b/src/Chainweb/Pact/Backend/Compaction.hs
@@ -68,7 +68,7 @@ import "yet-another-logger" System.Logger hiding (Logger)
 import "yet-another-logger" System.Logger qualified as YAL
 import "yet-another-logger" System.Logger.Backend.ColorOption (useColor)
 import Chainweb.BlockHash
-import Chainweb.BlockHeader (blockHeight, blockHash, blockPayloadHash)
+import Chainweb.BlockHeader (blockHeight, blockForkNumber, blockHash, blockPayloadHash)
 import Chainweb.BlockHeaderDB.Internal (BlockHeaderDb(..), RankedBlockHeader(..))
 import Chainweb.BlockHeight (BlockHeight(..))
 import Chainweb.Cut.CutHashes (cutIdToText)
@@ -762,7 +762,7 @@ doCompactRocksDb logger cwVersion cids minBlockHeight srcDb targetDb = do
         iterLast it
         iterValue it >>= \case
           Nothing -> exitLog logger "Missing final payload. This is likely due to a corrupted database."
-          Just rbh -> pure (_getRankedBlockHeader rbh ^. blockHeight)
+          Just rbh -> pure $ _getRankedBlockHeader rbh
 
       -- The header that we start at depends on whether or not
       -- we have a minimal block header history window.
@@ -772,7 +772,10 @@ doCompactRocksDb logger cwVersion cids minBlockHeight srcDb targetDb = do
       --
       -- On new enough chainweb versions, we want to only copy over
       -- the minimal number of block headers.
-      case minimumBlockHeaderHistory cwVersion latestHeader of
+      -- Note, this behaviour may be dangerous in case of changes on the miniumum block history.
+      --
+      -- TODO = Option to prune headers history to the minimum should be enabled by flag.
+      case minimumBlockHeaderHistory cwVersion (latestHeader ^. blockForkNumber) (latestHeader ^. blockHeight) of
         -- Go to the earliest possible entry. We migrate all BlockHeaders, for now.
         -- They are needed for SPV.
         --
@@ -791,16 +794,18 @@ doCompactRocksDb logger cwVersion cids minBlockHeight srcDb targetDb = do
       earliestHeader <- do
         iterValue it >>= \case
           Nothing -> exitLog logger "Missing first payload. This is likely due to a corrupted database."
-          Just rbh -> pure (_getRankedBlockHeader rbh ^. blockHeight)
+          Just rbh -> pure $ _getRankedBlockHeader rbh
 
       -- Ensure that we log progress 100 times per chain
       -- I just made this number up as something that felt somewhat sensible
-      let offset = (latestHeader - earliestHeader) `div` 100
-      let headerProgressPoints = [earliestHeader + i * offset | i <- [1..100]]
+      let latestHeight = latestHeader ^. blockHeight
+          earliestHeight = earliestHeader ^. blockHeight
+          offset = (latestHeight - earliestHeight) `div` 100
+      let headerProgressPoints = [earliestHeight + i * offset | i <- [1..100]]
 
       let logHeaderProgress bHeight = do
             when (bHeight `elem` headerProgressPoints) $ do
-              let percentDone = sshow $ 100 * fromIntegral @_ @Double (bHeight - earliestHeader) / fromIntegral @_ @Double (latestHeader - earliestHeader)
+              let percentDone = sshow $ 100 * fromIntegral @_ @Double (bHeight - earliestHeight) / fromIntegral @_ @Double (latestHeight - earliestHeight)
               log' LL.Info $ percentDone <> "% done."
 
       let go = do

--- a/src/Chainweb/Pact/PactService/Pact4/ExecBlock.hs
+++ b/src/Chainweb/Pact/PactService/Pact4/ExecBlock.hs
@@ -95,6 +95,7 @@ import Chainweb.Payload.PayloadStore
 import Chainweb.Time
 import Chainweb.Utils hiding (check)
 import Chainweb.Version
+import Chainweb.ForkState (pact4ForkNumber)
 import Chainweb.Version.Guards
 import Chainweb.Pact4.Backend.ChainwebPactDb
 import Data.Coerce
@@ -163,7 +164,7 @@ execBlock currHeader payload = do
     return (totalGasUsed, pwo)
   where
     blockGasLimit =
-      fromIntegral <$> maxBlockGasLimit v (view blockHeight currHeader)
+      fromIntegral <$> maxBlockGasLimit v pact4ForkNumber (view blockHeight currHeader)
 
     logInitCache = liftPactServiceM $ do
       mc <- fmap (fmap instr . _getModuleCache) <$> use psInitCache

--- a/src/Chainweb/Pact4/ModuleCache.hs
+++ b/src/Chainweb/Pact4/ModuleCache.hs
@@ -72,3 +72,4 @@ cleanModuleCache v cid bh =
         ForkAtBlockHeight bh' -> bh == bh'
         ForkAtGenesis -> bh == genesisHeight v cid
         ForkNever -> False
+        ForkAtForkNumber _ -> error "ChainWeb217Pact is not supposed to be indexed by a ForkNumber"

--- a/src/Chainweb/Pact4/TransactionExec.hs
+++ b/src/Chainweb/Pact4/TransactionExec.hs
@@ -144,6 +144,7 @@ import qualified Pact.Utils.StableHashMap as SHM
 
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight
+import Chainweb.ForkState (pact4ForkNumber)
 import Chainweb.Logger
 import qualified Chainweb.ChainId as Chainweb
 import Chainweb.Mempool.Mempool (pact4RequestKeyToTransactionHash)
@@ -371,7 +372,7 @@ applyCmd v logger gasLogger txFailuresCounter pdbenv miner gasModel txCtx txIdxI
     chainweb217Pact' = guardCtx chainweb217Pact txCtx
     chainweb219Pact' = guardCtx chainweb219Pact txCtx
     chainweb223Pact' = guardCtx chainweb223Pact txCtx
-    allVerifiers = verifiersAt v cid currHeight
+    allVerifiers = verifiersAt v cid pact4ForkNumber currHeight
     toEmptyPactError (PactError errty _ _ _) = PactError errty noInfo [] mempty
 
     toOldListErr pe = pe { peDoc = listErrMsg }
@@ -671,7 +672,8 @@ applyLocal logger gasLogger dbEnv gasModel txCtx spv cmdIn mc execConfig =
     currHeight = ctxCurrentBlockHeight txCtx
     cid = V._chainId txCtx
     v = _chainwebVersion txCtx
-    allVerifiers = verifiersAt v cid currHeight
+
+    allVerifiers = verifiersAt v cid pact4ForkNumber currHeight
     -- Note [Throw out verifier proofs eagerly]
     !verifiersWithNoProof =
         (fmap . fmap) (\_ -> ()) verifiers

--- a/src/Chainweb/Pact5/TransactionExec.hs
+++ b/src/Chainweb/Pact5/TransactionExec.hs
@@ -183,7 +183,7 @@ runVerifiers txCtx cmd = do
       gasUsed <- liftIO . readIORef . _geGasRef . _txEnvGasEnv =<< ask
       let initGasRemaining = MilliGas $ case (gasToMilliGas (gasLimit ^. _GasLimit), gasUsed) of
             (MilliGas gasLimitMilliGasWord, MilliGas gasUsedMilliGasWord) -> gasLimitMilliGasWord - gasUsedMilliGasWord
-      let allVerifiers = verifiersAt v (_chainId txCtx) (ctxCurrentBlockHeight txCtx)
+      let allVerifiers = verifiersAt v (_chainId txCtx) (ctxParentForkNumber txCtx) (ctxCurrentBlockHeight txCtx)
       let toModuleName m =
             Pact4.ModuleName
                     { Pact4._mnName = _mnName m

--- a/src/Chainweb/Pact5/Types.hs
+++ b/src/Chainweb/Pact5/Types.hs
@@ -11,6 +11,7 @@ module Chainweb.Pact5.Types
     ( TxContext(..)
     , guardCtx
     , ctxCurrentBlockHeight
+    , ctxParentForkNumber
     , GasSupply(..)
     , PactBlockM(..)
     , PactBlockState(..)
@@ -34,6 +35,7 @@ import Chainweb.BlockHeader
 import Chainweb.Miner.Pact (Miner)
 import Chainweb.BlockHeight
 import Chainweb.Version
+import Chainweb.ForkState
 import Chainweb.Pact.Types
 import qualified Chainweb.ChainId
 import Control.Lens
@@ -83,6 +85,9 @@ ctxBlockHeader = _parentHeader . _tcParentHeader
 -- which influenced legacy switch checks as well.
 ctxCurrentBlockHeight :: TxContext -> BlockHeight
 ctxCurrentBlockHeight = succ . view blockHeight . ctxBlockHeader
+
+ctxParentForkNumber :: TxContext -> ForkNumber
+ctxParentForkNumber = view blockForkNumber . ctxBlockHeader
 
 ctxChainId :: TxContext -> Chainweb.ChainId.ChainId
 ctxChainId = _chainId . ctxBlockHeader

--- a/src/Chainweb/Pact5/Types.hs
+++ b/src/Chainweb/Pact5/Types.hs
@@ -86,6 +86,11 @@ ctxBlockHeader = _parentHeader . _tcParentHeader
 ctxCurrentBlockHeight :: TxContext -> BlockHeight
 ctxCurrentBlockHeight = succ . view blockHeight . ctxBlockHeader
 
+-- We use the parent fork number in Pact, so when the fork
+-- number is incremented, only that block's descendents will
+-- have the forking behavior active. We do this because computing
+-- the "currently active fork number" requires information from adjacent 
+-- headers, which is not actually available yet when we execute a new Pact payload.
 ctxParentForkNumber :: TxContext -> ForkNumber
 ctxParentForkNumber = view blockForkNumber . ctxBlockHeader
 

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -358,6 +358,11 @@ instance Ord ForkHeight where
 --          ..
 --   - ForkNumber = n
 --   - ForkNever
+--
+-- During the LLC era, forks were triggered by block heights, with a fork number of 0 (called feature flag).
+-- After version 3.1, forks are ONLY triggered by fork numbers, as soon as the fork number becomes equal to 1.
+-- So the fork heights are sorted chronologically: first block heights, then fork numbers.
+
 
 makePrisms ''ForkHeight
 

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -350,8 +350,8 @@ instance Ord ForkHeight where
 -- We consider the following ordering for Forks:
 --   - ForkAtGenesis
 --   - ForkNumber = 0  (unusual case)
---   - BlockHeihgt = 0 (unusual case)
---   - Blockkheight = 1
+--   - BlockHeight = 0 (unusual case)
+--   - BlockHeight = 1
 --          ..
 --   - BlockHeight = n
 --   - ForkNumber = 1
@@ -361,7 +361,7 @@ instance Ord ForkHeight where
 
 makePrisms ''ForkHeight
 
-succByHeight:: ForkHeight -> ForkHeight
+succByHeight :: ForkHeight -> ForkHeight
 succByHeight (ForkAtBlockHeight x) = ForkAtBlockHeight $ succ x
 succByHeight ForkNever = ForkNever
 succByHeight _ = error "Only a Blockheight defined fork can be succ'ed"

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -37,6 +37,7 @@ module Chainweb.Version
     -- * Properties of Chainweb Version
       Fork(..)
     , ForkHeight(..)
+    , succByHeight
     , _ForkAtBlockHeight
     , _ForkAtGenesis
     , _ForkNever
@@ -322,11 +323,48 @@ instance FromJSON Fork where
 instance FromJSONKey Fork where
     fromJSONKey = FromJSONKeyTextParser $ either fail return . eitherFromText
 
-data ForkHeight = ForkAtBlockHeight !BlockHeight | ForkAtGenesis | ForkNever
-    deriving stock (Generic, Eq, Ord, Show)
+data ForkHeight =  ForkAtForkNumber !ForkNumber | ForkAtBlockHeight !BlockHeight | ForkAtGenesis | ForkNever
+    deriving stock (Generic, Eq, Show)
     deriving anyclass (Hashable, NFData)
 
+instance Bounded ForkHeight where
+    minBound = ForkAtGenesis
+    maxBound = ForkNever
+
+instance Ord ForkHeight where
+    compare ForkAtGenesis ForkAtGenesis = EQ
+    compare ForkNever ForkNever = EQ
+    compare (ForkAtForkNumber a) (ForkAtForkNumber b) = compare a b
+    compare (ForkAtBlockHeight a)  (ForkAtBlockHeight b) = compare a b
+    compare ForkAtGenesis  _ = LT
+    compare _ ForkAtGenesis = GT
+    compare ForkNever _ = GT
+    compare _ ForkNever = LT
+    compare (ForkAtForkNumber fn) (ForkAtBlockHeight _)
+        | fn == 0 = LT
+        | otherwise = GT
+    compare (ForkAtBlockHeight _) (ForkAtForkNumber fn)
+        | fn == 0 = GT
+        | otherwise = LT
+
+-- We consider the following ordering for Forks:
+--   - ForkAtGenesis
+--   - ForkNumber = 0  (unusual case)
+--   - BlockHeihgt = 0 (unusual case)
+--   - Blockkheight = 1
+--          ..
+--   - BlockHeight = n
+--   - ForkNumber = 1
+--          ..
+--   - ForkNumber = n
+--   - ForkNever
+
 makePrisms ''ForkHeight
+
+succByHeight:: ForkHeight -> ForkHeight
+succByHeight (ForkAtBlockHeight x) = ForkAtBlockHeight $ succ x
+succByHeight ForkNever = ForkNever
+succByHeight _ = error "Only a Blockheight defined fork can be succ'ed"
 
 newtype ChainwebVersionName =
     ChainwebVersionName { getChainwebVersionName :: T.Text }
@@ -491,9 +529,9 @@ data ChainwebVersion
         --
         -- NOTE: This is internal. For the actual size of the serialized header
         -- use 'headerSizeBytes'.
-    , _versionMaxBlockGasLimit :: Rule BlockHeight (Maybe Natural)
+    , _versionMaxBlockGasLimit :: Rule ForkHeight (Maybe Natural)
         -- ^ The maximum gas limit for an entire block.
-    , _versionSpvProofRootValidWindow :: Rule BlockHeight (Maybe Word64)
+    , _versionSpvProofRootValidWindow :: Rule ForkHeight (Maybe Word64)
         -- ^ The minimum number of block headers a chainweb node should
         -- retain in its history at all times.
     , _versionBootstraps :: [PeerInfo]
@@ -504,7 +542,7 @@ data ChainwebVersion
         -- ^ Whether to disable any core functionality.
     , _versionDefaults :: VersionDefaults
         -- ^ Version-specific defaults that can be overridden elsewhere.
-    , _versionVerifierPluginNames :: ChainMap (Rule BlockHeight (Set VerifierName))
+    , _versionVerifierPluginNames :: ChainMap (Rule ForkHeight (Set VerifierName))
         -- ^ Verifier plugins that can be run to verify transaction contents.
     , _versionQuirks :: VersionQuirks
         -- ^ Modifications to behavior at particular blockheights

--- a/src/Chainweb/Version/Guards.hs
+++ b/src/Chainweb/Version/Guards.hs
@@ -335,13 +335,18 @@ pact4ParserVersion v cid bh
     | chainweb213Pact v cid bh = Pact4.PactParserChainweb213
     | otherwise = Pact4.PactParserGenesis
 
-maxBlockGasLimit :: ChainwebVersion -> BlockHeight -> Maybe Natural
-maxBlockGasLimit v bh = snd $ ruleZipperHere $ snd
-    $ ruleSeek (\h _ -> ForkAtBlockHeight bh >= h) (_versionMaxBlockGasLimit v)
+maxBlockGasLimit :: ChainwebVersion -> ForkNumber -> BlockHeight -> Maybe Natural
+maxBlockGasLimit v fn bh = snd $ ruleZipperHere $ snd
+    $ ruleSeek (\h _ -> searchKey >= h) (_versionMaxBlockGasLimit v)
+    where
+        searchKey = ForkAtBlockHeight bh `max` ForkAtForkNumber fn
 
-minimumBlockHeaderHistory :: ChainwebVersion -> BlockHeight -> Maybe Word64
-minimumBlockHeaderHistory v bh = snd $ ruleZipperHere $ snd
-    $ ruleSeek (\h _ -> ForkAtBlockHeight bh >= h) (_versionSpvProofRootValidWindow v)
+
+minimumBlockHeaderHistory :: ChainwebVersion -> ForkNumber -> BlockHeight -> Maybe Word64
+minimumBlockHeaderHistory v fn bh = snd $ ruleZipperHere $ snd
+    $ ruleSeek (\h _ -> searchKey >= h) (_versionSpvProofRootValidWindow v)
+    where
+        searchKey = ForkAtBlockHeight bh `max` ForkAtForkNumber fn
 
 -- | Different versions of Chainweb allow different PPKSchemes.
 --

--- a/src/Chainweb/Version/Mainnet.hs
+++ b/src/Chainweb/Version/Mainnet.hs
@@ -164,11 +164,11 @@ mainnet = ChainwebVersion
     , _versionWindow = WindowWidth 120
     , _versionHeaderBaseSizeBytes = 318 - 110
     , _versionMaxBlockGasLimit =
-        (succ $ mainnet ^?! versionForks . at Chainweb216Pact . _Just . atChain (unsafeChainId 0) . _ForkAtBlockHeight, Just 180_000) `Above`
+        (succByHeight $ mainnet ^?! versionForks . at Chainweb216Pact . _Just . atChain (unsafeChainId 0), Just 180_000) `Above`
         Bottom (minBound, Nothing)
     , _versionSpvProofRootValidWindow =
-        (succ $ mainnet ^?! versionForks . at Chainweb31 . _Just . atChain (unsafeChainId 0) . _ForkAtBlockHeight, Nothing) `Above`
-        (succ $ mainnet ^?! versionForks . at Chainweb231Pact . _Just . atChain (unsafeChainId 0) . _ForkAtBlockHeight, Just 20_000) `Above`
+        (succByHeight $ mainnet ^?! versionForks . at Chainweb31 . _Just . atChain (unsafeChainId 0), Nothing) `Above`
+        (succByHeight $ mainnet ^?! versionForks . at Chainweb231Pact . _Just . atChain (unsafeChainId 0) , Just 20_000) `Above`
         Bottom (minBound, Nothing)
     , _versionBootstraps = domainAddr2PeerInfo mainnetBootstrapHosts
     , _versionGenesis = VersionGenesis
@@ -223,7 +223,7 @@ mainnet = ChainwebVersion
         , _disableMempoolSync = False
         }
     , _versionVerifierPluginNames = AllChains $
-        (4_577_530, Set.fromList [VerifierName "hyperlane_v3_message"]) `Above`
+        (ForkAtBlockHeight $ BlockHeight 4_577_530, Set.fromList [VerifierName "hyperlane_v3_message"]) `Above`
         Bottom (minBound, mempty)
     , _versionQuirks = VersionQuirks
         { _quirkGasFees = onChains

--- a/src/Chainweb/Version/RecapDevelopment.hs
+++ b/src/Chainweb/Version/RecapDevelopment.hs
@@ -78,8 +78,8 @@ recapDevnet = ChainwebVersion
         Chainweb228Pact -> AllChains $ ForkAtBlockHeight $ BlockHeight 650
         Chainweb230Pact -> AllChains $ ForkAtBlockHeight $ BlockHeight 680
         Chainweb231Pact -> AllChains $ ForkAtBlockHeight $ BlockHeight 690
-        Chainweb31 -> AllChains $ ForkAtBlockHeight $ BlockHeight 700
-        MigratePlatformShare -> AllChains $ ForkAtBlockHeight $ BlockHeight 710
+        MigratePlatformShare -> AllChains $ ForkAtBlockHeight $ BlockHeight 700
+        Chainweb31 -> AllChains $ ForkAtBlockHeight $ BlockHeight 710
 
     , _versionUpgrades = foldr (chainZip HM.union) (AllChains mempty)
         [ indexByForkHeights recapDevnet

--- a/src/Chainweb/Version/RecapDevelopment.hs
+++ b/src/Chainweb/Version/RecapDevelopment.hs
@@ -124,7 +124,7 @@ recapDevnet = ChainwebVersion
         , _disableMempoolSync = False
         }
     , _versionVerifierPluginNames = AllChains $
-        (600, Set.fromList $ map VerifierName ["hyperlane_v3_message", "allow", "signed_list"]) `Above`
+        (ForkAtBlockHeight $ BlockHeight 600, Set.fromList $ map VerifierName ["hyperlane_v3_message", "allow", "signed_list"]) `Above`
         Bottom (minBound, mempty)
     , _versionQuirks = noQuirks
     , _versionForkNumber = 0

--- a/src/Chainweb/Version/Registry.hs
+++ b/src/Chainweb/Version/Registry.hs
@@ -78,6 +78,24 @@ unregisterVersion v = do
     then error "You cannot unregister mainnet or testnet04 versions"
     else atomicModifyIORef' versionMap $ \m -> (HM.delete (_versionCode v) m, ())
 
+validateNoHeightAfterChainweb31' :: ChainwebVersion -> ForkHeight -> Either String ()
+validateNoHeightAfterChainweb31' v fh =
+    case (fork31Height, fh) of
+        (Just (ForkAtBlockHeight refAth), ForkAtBlockHeight ath) ->
+            if ath > (refAth + 1)
+                then Left ("validateVersion: Forking rule must only defined by Fork numbers after Chainweb31: " ++ show ath ++ " > " ++ show refAth)
+            else Right ()
+        _ -> Right ()
+    where
+        fork31Height =  v ^? versionForks . at Chainweb31 . _Just . atChain (unsafeChainId 0)
+
+validateNoHeightAfterChainweb31 :: ChainwebVersion -> Either String ()
+validateNoHeightAfterChainweb31 v =
+       (mapM_ (mapM_ (validateNoHeightAfterChainweb31' v)) (v ^. versionForks))
+    >> (mapM_ (validateNoHeightAfterChainweb31' v . fst) $ ruleElems $ v ^. versionMaxBlockGasLimit)
+    >> (mapM_ (validateNoHeightAfterChainweb31' v . fst) $ ruleElems $ v ^. versionSpvProofRootValidWindow)
+    >> (mapM_ (mapM_ (validateNoHeightAfterChainweb31' v . fst) . ruleElems) $ v ^. versionVerifierPluginNames)
+
 validateVersion :: HasCallStack => ChainwebVersion -> IO ()
 validateVersion v = do
     evaluate (rnf v)
@@ -92,8 +110,12 @@ validateVersion v = do
                 | not (all hasAllChains (_versionForks v)) ]
             , [ "validateVersion: chain graphs do not decrease in block height"
                 | not (ruleValid (_versionGraphs v)) ]
-            , [ "validateVersion: block gas limits do not decrease in block height"
+            , [ "validateVersion: block gas limits rules do not decrease in fork number and height"
                 | not (ruleValid (_versionMaxBlockGasLimit v)) ]
+            , [ "validateVersion: verifiers rules do not decrease in in fork number and height"
+                | not (all ruleValid (_versionVerifierPluginNames v)) ]
+             , [ "validateVersion: SPV valid window rules do not decrease in in fork number and height"
+                | not ( ruleValid (_versionSpvProofRootValidWindow v)) ]
             , [ "validateVersion: genesis data is missing for some chains"
                 | not (and
                     [ hasAllChains (_genesisBlockPayload $ _versionGenesis v)
@@ -102,6 +124,8 @@ validateVersion v = do
                     ])]
             , [ "validateVersion: some pact upgrade has no transactions"
                 | any (any isUpgradeEmpty) (_versionUpgrades v) ]
+            , [ err
+                | Left err <- [validateNoHeightAfterChainweb31 v] ]
             -- TODO: check that pact 4/5 upgrades are only enabled when pact 4/5 is enabled
             ]
     unless (null errors) $

--- a/src/Chainweb/Version/Testnet04.hs
+++ b/src/Chainweb/Version/Testnet04.hs
@@ -144,10 +144,10 @@ testnet04 = ChainwebVersion
     , _versionWindow = WindowWidth 120
     , _versionHeaderBaseSizeBytes = 318 - 110
     , _versionMaxBlockGasLimit =
-        (succ $ testnet04 ^?! versionForks . at Chainweb216Pact . _Just . atChain (unsafeChainId 0) . _ForkAtBlockHeight, Just 180_000) `Above`
+        (succByHeight $ testnet04 ^?! versionForks . at Chainweb216Pact . _Just . atChain (unsafeChainId 0) , Just 180_000) `Above`
         Bottom (minBound, Nothing)
     , _versionSpvProofRootValidWindow =
-        (succ $ testnet04 ^?! versionForks . at Chainweb231Pact . _Just . atChain (unsafeChainId 0) . _ForkAtBlockHeight, Just 20_000) `Above`
+        (succByHeight $ testnet04 ^?! versionForks . at Chainweb231Pact . _Just . atChain (unsafeChainId 0) , Just 20_000) `Above`
         Bottom (minBound, Nothing)
     , _versionBootstraps = domainAddr2PeerInfo testnet04BootstrapHosts
     , _versionGenesis = VersionGenesis
@@ -190,7 +190,7 @@ testnet04 = ChainwebVersion
         { _disablePeerValidation = False
         , _disableMempoolSync = False
         }
-    , _versionVerifierPluginNames = AllChains $ (4_100_681, Set.fromList [VerifierName "hyperlane_v3_message"]) `Above`
+    , _versionVerifierPluginNames = AllChains $ (ForkAtBlockHeight $ BlockHeight $ 4_100_681, Set.fromList [VerifierName "hyperlane_v3_message"]) `Above`
         Bottom (minBound, mempty)
     , _versionQuirks = VersionQuirks
         { _quirkGasFees = onChains

--- a/src/Chainweb/Version/Utils.hs
+++ b/src/Chainweb/Version/Utils.hs
@@ -466,7 +466,7 @@ verifiersAt v cid bh =
         = snd
         $ ruleZipperHere
         $ snd
-        $ ruleSeek (\h _ -> bh >= h)
+        $ ruleSeek (\h _ -> ForkAtBlockHeight bh >= h)
         $ _versionVerifierPluginNames v ^?! atChain cid
 
 -- the mappings from names to verifier plugins is global. the list of verifier

--- a/src/Chainweb/Version/Utils.hs
+++ b/src/Chainweb/Version/Utils.hs
@@ -64,6 +64,7 @@ import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Difficulty
 import Chainweb.Time
+import Chainweb.ForkState
 import Chainweb.VerifierPlugin
 import qualified Chainweb.VerifierPlugin.Allow
 import qualified Chainweb.VerifierPlugin.Hyperlane.Announcement
@@ -458,16 +459,17 @@ expectedCutHeightAfterSeconds v s = eh * int (chainCountAt v (round eh))
     eh = expectedBlockHeightAfterSeconds v s
 
 -- | The verifier plugins enabled for a particular block.
-verifiersAt :: ChainwebVersion -> ChainId -> BlockHeight -> Map VerifierName VerifierPlugin
-verifiersAt v cid bh =
+verifiersAt :: ChainwebVersion -> ChainId -> ForkNumber -> BlockHeight -> Map VerifierName VerifierPlugin
+verifiersAt v cid fn bh =
     M.restrictKeys allVerifierPlugins activeVerifierNames
     where
     activeVerifierNames
         = snd
         $ ruleZipperHere
         $ snd
-        $ ruleSeek (\h _ -> ForkAtBlockHeight bh >= h)
+        $ ruleSeek (\h _ -> searchKey >= h)
         $ _versionVerifierPluginNames v ^?! atChain cid
+    searchKey = ForkAtBlockHeight bh `max` ForkAtForkNumber fn
 
 -- the mappings from names to verifier plugins is global. the list of verifier
 -- plugins active in any particular block validation context is the only thing

--- a/test/lib/Chainweb/Test/TestVersions.hs
+++ b/test/lib/Chainweb/Test/TestVersions.hs
@@ -529,7 +529,7 @@ pact5InstantCpmTestVersionExpiryDisabled g = buildTestVersion $ \v -> v
             )
         )
     & versionSpvProofRootValidWindow .~
-        ( (BlockHeight 5, Nothing) `Above`
+        ( (ForkAtBlockHeight $ BlockHeight 5, Nothing) `Above`
             Bottom (minBound, Just 20)
         )
 

--- a/test/lib/Chainweb/Test/TestVersions.hs
+++ b/test/lib/Chainweb/Test/TestVersions.hs
@@ -330,8 +330,9 @@ slowForks = tabulateHashMap \case
     Chainweb228Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 145)
     Chainweb230Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 155)
     Chainweb231Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 160)
-    Chainweb31 -> AllChains $ ForkAtBlockHeight (BlockHeight 165)
-    MigratePlatformShare -> AllChains $ ForkAtBlockHeight (BlockHeight 170)
+    MigratePlatformShare -> AllChains $ ForkAtBlockHeight (BlockHeight 165)
+    Chainweb31 -> AllChains $ ForkAtBlockHeight (BlockHeight 170)
+
 
 -- | A set of fork heights which are relatively fast, but not fast enough to break anything.
 fastForks :: HashMap Fork (ChainMap ForkHeight)

--- a/test/unit/Chainweb/Test/Pact5/RemotePactTest.hs
+++ b/test/unit/Chainweb/Test/Pact5/RemotePactTest.hs
@@ -397,7 +397,7 @@ spvExpirationTest v baseRdb prop = runResourceT $ do
         -- disabled" case, we definitely don't want to use maxBound.
         let expirationWindow = fromMaybe
                 (error "missing minimumBlockHeaderHistory")
-                (minimumBlockHeaderHistory v minBound)
+                (minimumBlockHeaderHistory v minBound minBound)
         when (int expirationWindow < waitBlocks + diameter (chainGraphAt v maxBound)) $ assertFailure "test version has a minimumBlockHeaderHistory that is too short to test"
 
         replicateM_ waitBlocks $ advanceAllChains_ fx


### PR DESCRIPTION
The objective of this PR is to make a standardized and homogeneous way to manage forks and rules by Height, and fork numbers.

The object ForkHeight as been extended to manage fork numbers as well.
Compare rules have been moved to the data definition from the predicates (after, atOrAfter, ...). 

The same object can now be used for Rules definition too. 

A new checkFork' function has been added to manage forks by numbers, while the old checkFork function still manages forks by heights.

Postulate: starting with fork number 1, no forks or rules change will use heights anymore.

Note : upgrades don't support fork numbers for now, as it requires a more complex mechanism.
